### PR TITLE
added author info tags for researchgate and google_scholar

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -106,6 +106,8 @@ author:
   weibo            :
   xing             :
   youtube          :
+  google_scholar   : "VGaoB64AAAAJ&hl"
+  researchgate     : "Kelly_Caylor"
 
 
 # Reading Files

--- a/_includes/author-profile.html
+++ b/_includes/author-profile.html
@@ -91,6 +91,18 @@
           Facebook
         </a></li>
       {% endif %}
+      {% if author.google_scholar %}
+        <li><a href="https://scholar.google.com/citations?user={{ author.google_scholar}}" itemprop="sameAs">
+        <i class="fa fa-fw fa-book" aria-hidden="true"></i>
+        Google Scholar
+        </a></li>
+      {% endif %}
+      {% if author.researchgate %}
+        <li><a href="https://www.researchgate.net/profile/{{ author.researchgate}}" itemprop="sameAs">
+        <i class="fa fa-fw fa-flask" aria-hidden="true"></i>
+        Research Gate
+        </a></li>
+      {% endif %}
       {% if author.google_plus %}
         <li><a href="https://plus.google.com/+{{ author.google_plus }}" itemprop="sameAs">
           <i class="fa fa-fw fa-google-plus-square" aria-hidden="true"></i> 


### PR DESCRIPTION
To use this feature add the following tags to your information in `_data/authors.yaml`

google_scholar : `unique google scholar id` 

(Kelly's is `VGaoB64AAAAJ`, based on https://scholar.google.com/citations?user=VGaoB64AAAAJ)

reasearchgate: `your name for your _public_ researchgate profile`

(Kelly's is `Kelly_Caylor`, based on https://www.researchgate.net/profile/Kelly_Caylor)

You must have a public profile on researchgate for this to work. You can make your profile public in the researchgate settings in side your account.